### PR TITLE
Remove Wayland socket access

### DIFF
--- a/com.getmailspring.Mailspring.yml
+++ b/com.getmailspring.Mailspring.yml
@@ -15,7 +15,6 @@ tags: [proprietary]
 finish-args:
   - --share=ipc
   - --socket=fallback-x11
-  - --socket=wayland
   - --socket=pulseaudio
   - --share=network
   - --device=dri


### PR DESCRIPTION
As discussed in the [Mailspring Community](
https://community.getmailspring.com/t/flatpak-distribution-on-linux/68/20), running in Wayland returns the error `Failed to generate minidump.%`, and removing the access to wayland socket makes it work.  

So until it works with Wayland, I propose removing this permission.