### PR TITLE
Fix argument passing

### DIFF
--- a/com.getmailspring.Mailspring.yml
+++ b/com.getmailspring.Mailspring.yml
@@ -59,6 +59,6 @@ modules:
       - type: script
         dest-filename: start-mailspring
         commands:
-          - exec env TMPDIR=$XDG_CACHE_HOME zypak-wrapper mailspring -s $EXTRA_ARGS \"$@\"
+          - exec env TMPDIR=$XDG_CACHE_HOME zypak-wrapper mailspring -s $EXTRA_ARGS "$@"
       - type: file
         path: mailspring.appdata.xml


### PR DESCRIPTION
Arguments passing to `flatpak run com.getmailspring.Mailspring` didn't work (e.g. -b, --background) because of escaping quotes in start-mailspring script.

This pull request fixes this issue.